### PR TITLE
Change min_confirmations to avoid self lock

### DIFF
--- a/ansible/inventory/host_vars/explorer-vrc/explorer.yml
+++ b/ansible/inventory/host_vars/explorer-vrc/explorer.yml
@@ -7,7 +7,7 @@ explorer:
   coin:
     name: "Vericoin"
     symbol: "VRC"
-    min_confirmations: 10
+    min_confirmations: 50
     type: "PoST"
     github: "https://github.com/VeriConomy"
     telegram: "https://t.me/VeriCoinandVerium/"


### PR DESCRIPTION
To avoid self lock and because of some instability of the PoST, we should increase the value to 50 instead of 10.